### PR TITLE
refactor(Dockerfile): optimize container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,16 @@
 FROM golang:1.20-alpine as build-stage
 
-LABEL name "NezukoChan Image Proxy (Docker Build)"
-LABEL maintainer "KagChi"
-
 WORKDIR /tmp/build
 
 COPY . .
 
 # Install needed deps
-RUN apk add libc-dev vips-dev gcc g++ make
+RUN apk add --no-cache libc-dev vips-dev gcc g++ make
 
 # Build the project
 RUN go build cmd/server/main.go
 
-FROM golang:1.20-alpine
+FROM alpine:3
 
 LABEL name "NezukoChan Image Proxy"
 LABEL maintainer "KagChi"
@@ -21,8 +18,9 @@ LABEL maintainer "KagChi"
 WORKDIR /app
 
 # Install needed deps
-RUN apk add vips
+RUN apk add --no-cache vips tini
 
 COPY --from=build-stage /tmp/build/main main
 
-CMD ["./main"]
+ENTRYPOINT ["tini", "--"]
+CMD ["/app/main"]


### PR DESCRIPTION
Some points:
- We don't need label on build stage, you don't label incomplete products in factory yes?
- It is prefered to use `--no-cache` in apk, to not cache package indexes, especially in final image, and will reduce image size
- Golang is a compiled language, without any Intermediate Language like Bytecode in Java, thus you don't need to install Golang in final image
- It is advised to not run your app as a PID 1 in container, and using an init system. For containers, we just need a simple init system like `tini`, some of the benefits you can see here: [why-tini](https://github.com/krallin/tini#why-tini)


This reduces image from 320MB to 71.4MB in size.